### PR TITLE
fix groobyVR Scraper

### DIFF
--- a/pkg/scrape/groobyvr.go
+++ b/pkg/scrape/groobyvr.go
@@ -105,7 +105,7 @@ func GroobyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 	})
 
 	siteCollector.OnHTML(`div.videohere a`, func(e *colly.HTMLElement) {
-		sceneURL := "https:" + e.Request.AbsoluteURL(e.Attr("href"))
+		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
 
 		if !funk.ContainsString(knownScenes, sceneURL) {
 			sceneCollector.Visit(sceneURL)


### PR DESCRIPTION
removing the extra https: added Infront of the scene URL while scraping